### PR TITLE
Remove self-link from post title

### DIFF
--- a/templates/macros/macros.html
+++ b/templates/macros/macros.html
@@ -23,9 +23,7 @@
 
 
 {%- macro title_post(page, config) %}
-{%- set uglyurls = config.extra.uglyurls | default(value=false) -%}
-{%- if config.extra.search_library %}{%- if config.extra.search_library == "offline" %}{% set uglyurls = true %}{% endif %}{% endif %}
-      <h1><a href="{{ page.permalink | safe }}{%- if uglyurls %}index.html{%- endif %}">{{ page.title | markdown(inline=true) | safe }}</a></h1>
+      <h1>{{ page.title | markdown(inline=true) | safe }}</h1>
 {%- endmacro title_post %}
 
 


### PR DESCRIPTION
## Summary
- remove anchor from `title_post` macro

## Testing
- `zola build` *(fails: `load_data` could not fetch external resource)*

------
https://chatgpt.com/codex/tasks/task_e_684ddf9a2b388329a67ced7f3a854819